### PR TITLE
Simplify Lambda integration example

### DIFF
--- a/website/docs/r/api_gateway_integration.html.markdown
+++ b/website/docs/r/api_gateway_integration.html.markdown
@@ -85,7 +85,7 @@ resource "aws_api_gateway_integration" "integration" {
   http_method             = "${aws_api_gateway_method.method.http_method}"
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
-  uri                     = "arn:aws:apigateway:${var.myregion}:lambda:path/2015-03-31/functions/${aws_lambda_function.lambda.arn}/invocations"
+  uri                     = "${aws_lambda_function.lambda.invoke_arn}"
 }
 
 # Lambda


### PR DESCRIPTION
Based on [aws_lambda_function's documentation](https://www.terraform.io/docs/providers/aws/r/lambda_function.html#invoke_arn), we can use aws_lambda_function.invoke_arn as the 'uri' in a definition of an 'aws_api_gateway_integration' resource.